### PR TITLE
fix[auth]: remove extra bearer header

### DIFF
--- a/polytope/api/Auth.py
+++ b/polytope/api/Auth.py
@@ -53,9 +53,6 @@ class Auth:
         if user_key and not user_email:
             auth_headers.append("Bearer %s" % (user_key))
         config = self.config.get()
-        bearer_key = config["user_key"]
-        if bearer_key:
-            auth_headers.append("Bearer %s" % (bearer_key))
         username = config["username"]
         password = config["password"]
         if username and password:


### PR DESCRIPTION
it was issuing 2 bearer tokens, which is sort of a fix/partial revert of
https://github.com/ecmwf/polytope-client/commit/d20aa895176d7c55aba78a50dfffadbcbc3bc923