### PR TITLE
fix(ci): update python and github actions versions

### DIFF
--- a/.github/workflows/check-publish.yaml
+++ b/.github/workflows/check-publish.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Code QA
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: pip install black flake8 isort
       - run: black --version
       - run: isort --check .
@@ -33,14 +33,14 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     name: Python ${{ matrix.python-version }} on ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
     needs: quality
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install polytope-client
@@ -67,9 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
python 3.8 is now deprecated and actions for 3.7 are not even available